### PR TITLE
rename getDataForPath to getBCDDataForPath and make a named export

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -50,7 +50,7 @@ const filteredBrowsers = Object.fromEntries(
   ])
 ) as Browsers;
 
-export default function getDataForPath(path: string): Data | void {
+export function getBCDDataForPath(path: string): Data | void {
   const subtree = path
     .split(".")
     .reduce<Identifier | undefined>((prev, curr) => prev?.[curr], bcdAPIs);

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdn/bcd-utils-api",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Converts bcd data into json files usable by yari's bcd table",
   "homepage": "https://github.com/mdn/bcd-utils#readme",
   "bugs": {


### PR DESCRIPTION
using a default export was causing very weird problems in esm yari,
where this function was exported under `default.default`

change is compatible with cjs yari (provided the import is changed to
`{ getBCDDataForPath }`)

blocks https://github.com/mdn/yari/pull/7623

I'll open the yari PR once this is merged and published to npm