### PR TITLE
use the node 16 version of aws credentials

### DIFF
--- a/.github/workflows/deploy-prod-api.yml
+++ b/.github/workflows/deploy-prod-api.yml
@@ -27,7 +27,7 @@ jobs:
       - run: npm update @mdn/browser-compat-data
       - run: npm run generate
       - name: Configure AWS credentials for prod
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.PROD_AWS_ACCESS_KEY_SECRET }}

--- a/.github/workflows/deploy-prod-updates.yml
+++ b/.github/workflows/deploy-prod-updates.yml
@@ -26,7 +26,7 @@ jobs:
       - run: npm ci
       - run: npm run updates rumba
       - name: Configure AWS credentials for prod
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.UPDATES_PROD_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.UPDATES_PROD_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy-stage-api.yml
+++ b/.github/workflows/deploy-stage-api.yml
@@ -27,7 +27,7 @@ jobs:
       - run: npm update @mdn/browser-compat-data
       - run: npm run generate
       - name: Configure AWS credentials for stage
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.STAGE_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.STAGE_AWS_ACCESS_KEY_SECRET }}

--- a/.github/workflows/deploy-stage-updates.yml
+++ b/.github/workflows/deploy-stage-updates.yml
@@ -26,7 +26,7 @@ jobs:
       - run: npm ci
       - run: npm run updates rumba
       - name: Configure AWS credentials for stage
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.UPDATES_STAGE_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.UPDATES_STAGE_AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
see https://github.com/aws-actions/configure-aws-credentials#notice-node12-deprecation-warning