### PR TITLE
invalidate cdn in api deploy actions

### DIFF
--- a/.github/workflows/deploy-prod-api.yml
+++ b/.github/workflows/deploy-prod-api.yml
@@ -36,3 +36,8 @@ jobs:
           aws-region: us-west-2
       - run: aws s3 sync --acl public-read out/ s3://mdn-content-prod/main/bcd/api/
       - run: aws s3 sync --acl public-read --delete out/v0/current s3://mdn-content-prod/main/bcd/api/v0/current
+      - name: Invalidate CDN
+        env:
+          DISTRIBUTION: E2ZY2DGUN70EMI
+          PATHS: /bcd/api/*
+        run: aws cloudfront create-invalidation --distribution-id "$DISTRIBUTION" --paths "$PATHS"

--- a/.github/workflows/deploy-stage-api.yml
+++ b/.github/workflows/deploy-stage-api.yml
@@ -36,3 +36,8 @@ jobs:
           aws-region: us-west-2
       - run: aws s3 sync --acl public-read out/ s3://mdn-content-stage/main/bcd/api/
       - run: aws s3 sync --acl public-read --delete out/v0/current s3://mdn-content-stage/main/bcd/api/v0/current
+      - name: Invalidate CDN
+        env:
+          DISTRIBUTION: E2MLRMA1VTVDHX
+          PATHS: /bcd/api/*
+        run: aws cloudfront create-invalidation --distribution-id "$DISTRIBUTION" --paths "$PATHS"


### PR DESCRIPTION
updates aren't cached by the cdn so don't need to be invalidated
