### PR TITLE
chore(deps): move @mdn/browser-compat-data to peerDependencies

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,22 +1,22 @@
 {
   "name": "@mdn/bcd-utils-api",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mdn/bcd-utils-api",
-      "version": "0.0.1",
+      "version": "0.0.3",
       "license": "MPL-2.0",
-      "dependencies": {
-        "@mdn/browser-compat-data": "latest"
-      },
       "devDependencies": {
         "@types/node": "^16.18.0",
         "@types/semver": "^7.3.13",
         "semver": "^7.3.8",
         "ts-node": "^10.9.1",
         "typescript": "^4.9.3"
+      },
+      "peerDependencies": {
+        "@mdn/browser-compat-data": "^5.2.21"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -57,9 +57,10 @@
       }
     },
     "node_modules/@mdn/browser-compat-data": {
-      "version": "5.2.21",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.21.tgz",
-      "integrity": "sha512-xpQpnRfaEbNMlHoOhXt6rz22zOzAtdSPMcYZJpyG1HkL4qV3aEOfK+VQrQGvaj8eBVqvLgv/GVh0i3KsysIh7g=="
+      "version": "5.2.39",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.39.tgz",
+      "integrity": "sha512-m8EJuQlHl6GeBkryBfJCl9gOOw/5dCqQVzRWj6hBbDG3NTaJyypa5784lae/uklYildVwiqbP0iGl3LUEhECPg==",
+      "peer": true
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
@@ -283,9 +284,10 @@
       }
     },
     "@mdn/browser-compat-data": {
-      "version": "5.2.21",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.21.tgz",
-      "integrity": "sha512-xpQpnRfaEbNMlHoOhXt6rz22zOzAtdSPMcYZJpyG1HkL4qV3aEOfK+VQrQGvaj8eBVqvLgv/GVh0i3KsysIh7g=="
+      "version": "5.2.39",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.39.tgz",
+      "integrity": "sha512-m8EJuQlHl6GeBkryBfJCl9gOOw/5dCqQVzRWj6hBbDG3NTaJyypa5784lae/uklYildVwiqbP0iGl3LUEhECPg==",
+      "peer": true
     },
     "@tsconfig/node10": {
       "version": "1.0.9",

--- a/api/package.json
+++ b/api/package.json
@@ -19,14 +19,14 @@
     "generate": "ts-node cli.ts",
     "test": "npm run generate && rm -r out"
   },
-  "dependencies": {
-    "@mdn/browser-compat-data": "latest"
-  },
   "devDependencies": {
     "@types/node": "^16.18.0",
     "@types/semver": "^7.3.13",
     "semver": "^7.3.8",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.3"
+  },
+  "peerDependencies": {
+    "@mdn/browser-compat-data": "^5.2.21"
   }
 }


### PR DESCRIPTION
Resolves an issue in where the currently locked version of `@mdn/browser-compat-data` in this package is used in `mdn/yari` instead of the locked version over there.

I tested by running `npm test` (in `api/`) locally, and it succeeded.