### PR TITLE
feature(gcp): sync rumba-updates to prod GCS bucket

### DIFF
--- a/.github/workflows/deploy-prod-updates.yml
+++ b/.github/workflows/deploy-prod-updates.yml
@@ -9,11 +9,21 @@ on:
         default: ""
   schedule:
     - cron: "0 0 * * *"
+  workflow_call:
+    secrets:
+      GCP_PROJECT_NAME:
+        required: true
+      WIP_PROJECT_ID:
+        required: true
 
 jobs:
   deploy-prod-updates:
     name: Deploy to prod
     runs-on: ubuntu-latest
+    environment: prod
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         working-directory: updates
@@ -34,3 +44,17 @@ jobs:
           aws-secret-access-key: ${{ secrets.UPDATES_PROD_AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
       - run: aws s3 sync --acl public-read rumba-updates/ s3://updates-prod-developer-mozilla-e2b95ed55d379b1a/rumba-bcd-updates/
+
+      - name: Authenticate with GCP
+        uses: google-github-actions/auth@v0
+        with:
+          token_format: access_token
+          service_account: deploy-prod-updates@${{ secrets.GCP_PROJECT_NAME }}.iam.gserviceaccount.com
+          workload_identity_provider: projects/${{ secrets.WIP_PROJECT_ID }}/locations/global/workloadIdentityPools/github-actions/providers/github-actions
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v1
+
+      - name: Sync Rumba update
+        run: |-
+          gsutil -m -h "Cache-Control:public, max-age=86400" rsync -d -r rumba-updates/ gs://updates-prod-mdn/rumba-bcd-updates


### PR DESCRIPTION
The prod version of https://github.com/mdn/bcd-utils/pull/16