### PR TITLE
ci(deploy-stage-api): sync to /bcd/api in GCP, not /api

### DIFF
--- a/.github/workflows/deploy-stage-api.yml
+++ b/.github/workflows/deploy-stage-api.yml
@@ -64,5 +64,5 @@ jobs:
 
       - name: Sync Rumba API
         run: |-
-          gsutil -m -h "Cache-Control:public, max-age=86400" rsync -r out/ gs://bcd-stage-mdn/api/
-          gsutil -m -h "Cache-Control:public, max-age=86400" rsync -d -r out/v0/current gs://bcd-stage-mdn/api/v0/current
+          gsutil -m -h "Cache-Control:public, max-age=86400" rsync -r out/ gs://bcd-stage-mdn/bcd/api/
+          gsutil -m -h "Cache-Control:public, max-age=86400" rsync -d -r out/v0/current gs://bcd-stage-mdn/bcd/api/v0/current


### PR DESCRIPTION
This makes the paths backwards-compatible:

```md
https://    developer.allizom.org/bcd/api/v0/current/api.Window.json
              vvv
https://bcd.developer.allizom.org/bcd/api/v0/current/api.Window.json
```