### PR TITLE
fix(api): don't splice the path

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -57,7 +57,7 @@ export function getBCDDataForPath(path: string): Data | void {
   if (subtree) {
     return {
       data: walk(subtree, path),
-      query: path.slice(1),
+      query: path,
       browsers: filteredBrowsers,
     };
   }


### PR DESCRIPTION
Caused the query to be missing its first character:

`ss.properties.background`
instead of
`css.properties.background`

Noticed as part of https://github.com/mdn/yari/pull/8470.

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/495429/226893110-2e841e2a-9b0b-476f-aad9-085a41c25683.png">
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/495429/226893138-95f49b80-a6a6-4f18-b1a5-b0bada9c0305.png">
