### PR TITLE
fix(api): remove locale from page links

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -140,11 +140,7 @@ function getPathFromAbsoluteURL(absoluteUrl?: string) {
     return absoluteUrl;
   }
 
-  const slug = url.pathname;
-  if (slug.startsWith("/docs/")) {
-    return `/en-US${slug}`;
-  }
-  return slug;
+  return url.pathname;
 }
 
 function normalizeVersion(version?: VersionValue): string | undefined {

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mdn/bcd-utils-api",
-  "version": "0.0.4",
+  "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mdn/bcd-utils-api",
-      "version": "0.0.4",
+      "version": "0.0.3",
       "license": "MPL-2.0",
       "devDependencies": {
         "@types/node": "^16.18.0",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mdn/bcd-utils-api",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mdn/bcd-utils-api",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "MPL-2.0",
       "devDependencies": {
         "@types/node": "^16.18.0",


### PR DESCRIPTION
The browser compatibility list has a link to MDN.
This link always points to the English page, but preferably translated content is available.

So I removed `/en-US/` from the link url.
This will redirect you to the same translated page you are viewing.

For example,
`https://developer.mozilla.org/docs/Web/API/Window/DOMContentLoaded_event` is forwarded to `https://developer.mozilla.org/en-US/docs/Web/API/Window/DOMContentLoaded_event` for English users and to `https://developer.mozilla.org/ja/docs/Web/API/Window/DOMContentLoaded_event` for Japanese users. 

By the way, if a translated page does not exist, a link to the English page will be displayed.
https://developer.mozilla.org/ja/docs/Web/API/Window/setImmediate

# Related

mdn/translated-content#10781
