### PR TITLE
chore(bcd-utils-api): export interfaces from package

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -9,22 +9,22 @@ import bcd, {
   VersionValue,
 } from "@mdn/browser-compat-data";
 
-interface Data {
+export interface Data {
   data: IdentifierExtended;
   query: string;
   browsers: Browsers;
 }
 
-interface SimpleSupportStatementExtended extends SimpleSupportStatement {
+export interface SimpleSupportStatementExtended extends SimpleSupportStatement {
   release_date?: string;
   version_last?: VersionValue;
 }
 
-interface CompatStatementExtended extends CompatStatement {
+export interface CompatStatementExtended extends CompatStatement {
   support: Partial<Record<BrowserName, SimpleSupportStatementExtended[]>>;
 }
 
-interface IdentifierExtended {
+export interface IdentifierExtended {
   [key: string]: IdentifierExtended | CompatStatementExtended;
 }
 

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdn/bcd-utils-api",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Converts bcd data into json files usable by yari's bcd table",
   "homepage": "https://github.com/mdn/bcd-utils#readme",
   "bugs": {


### PR DESCRIPTION
we need to access them in yari
