### PR TITLE
chore(api): remove redundant sorting

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -100,9 +100,6 @@ function extendCompatStatement(
       )
         .map((simpleSupportStatement) =>
           extendSimpleSupportStatement(simpleSupportStatement, browserName)
-        )
-        .sort((a, b) =>
-          _compareVersions(_getFirstVersion(b), _getFirstVersion(a))
         ),
     ])
   );


### PR DESCRIPTION
This PR removes a redundant sorting clause during support statement remapping.  This line is not needed as BCD uses a more stable sorting system that ensures the first statement in the array is the one with the fullest, most standard support (in other words, what we want to show on Yari).  See mdn/yari#10140 for more details.