### PR TITLE
chore(ci): use `.nvmrc` to specify node version

### DIFF
--- a/.github/workflows/deploy-prod-api.yml
+++ b/.github/workflows/deploy-prod-api.yml
@@ -29,9 +29,9 @@ jobs:
         working-directory: api
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
           registry-url: "https://registry.npmjs.org/"
@@ -44,7 +44,7 @@ jobs:
       - run: npm run generate
 
       - name: Authenticate with GCP
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
         with:
           token_format: access_token
           service_account: deploy-prod-bcd@${{ secrets.GCP_PROJECT_NAME }}.iam.gserviceaccount.com

--- a/.github/workflows/deploy-prod-api.yml
+++ b/.github/workflows/deploy-prod-api.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version-file: .nvmrc
           registry-url: "https://registry.npmjs.org/"
           cache: npm
 

--- a/.github/workflows/deploy-prod-updates.yml
+++ b/.github/workflows/deploy-prod-updates.yml
@@ -29,8 +29,8 @@ jobs:
         working-directory: updates
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 19
           registry-url: "https://registry.npmjs.org/"
@@ -41,7 +41,7 @@ jobs:
       - run: npm run updates rumba
 
       - name: Authenticate with GCP
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
         with:
           token_format: access_token
           service_account: deploy-prod-updates@${{ secrets.GCP_PROJECT_NAME }}.iam.gserviceaccount.com
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - env:
           RUMBA_AUTH: ${{ secrets.RUMBA_PROD_API_KEY }}

--- a/.github/workflows/deploy-prod-updates.yml
+++ b/.github/workflows/deploy-prod-updates.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 19
+          node-version-file: .nvmrc
           registry-url: "https://registry.npmjs.org/"
           cache: npm
 

--- a/.github/workflows/deploy-stage-api.yml
+++ b/.github/workflows/deploy-stage-api.yml
@@ -29,9 +29,9 @@ jobs:
         working-directory: api
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
           registry-url: "https://registry.npmjs.org/"
@@ -44,7 +44,7 @@ jobs:
       - run: npm run generate
 
       - name: Authenticate with GCP
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
         with:
           token_format: access_token
           service_account: deploy-stage-bcd@${{ secrets.GCP_PROJECT_NAME }}.iam.gserviceaccount.com

--- a/.github/workflows/deploy-stage-api.yml
+++ b/.github/workflows/deploy-stage-api.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version-file: .nvmrc
           registry-url: "https://registry.npmjs.org/"
           cache: npm
 

--- a/.github/workflows/deploy-stage-updates.yml
+++ b/.github/workflows/deploy-stage-updates.yml
@@ -29,8 +29,8 @@ jobs:
         working-directory: updates
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 19
           registry-url: "https://registry.npmjs.org/"
@@ -41,7 +41,7 @@ jobs:
       - run: npm run updates rumba
 
       - name: Authenticate with GCP
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
         with:
           token_format: access_token
           service_account: deploy-stage-updates@${{ secrets.GCP_PROJECT_NAME }}.iam.gserviceaccount.com
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - env:
           RUMBA_AUTH: ${{ secrets.RUMBA_STAGE_API_KEY }}

--- a/.github/workflows/deploy-stage-updates.yml
+++ b/.github/workflows/deploy-stage-updates.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 19
+          node-version-file: .nvmrc
           registry-url: "https://registry.npmjs.org/"
           cache: npm
 

--- a/.github/workflows/publish-package-api.yml
+++ b/.github/workflows/publish-package-api.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version-file: .nvmrc
           registry-url: "https://registry.npmjs.org/"
           cache: npm
       - run: npm ci

--- a/.github/workflows/publish-package-api.yml
+++ b/.github/workflows/publish-package-api.yml
@@ -17,8 +17,8 @@ jobs:
         working-directory: api
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
           registry-url: "https://registry.npmjs.org/"


### PR DESCRIPTION
The release log:

- [actions/checkout@v4](https://github.com/actions/checkout/releases/tag/v4.0.0)
- [actions/setup-node@v4](https://github.com/actions/setup-node/releases/tag/v4.0.0)
- [google-github-actions/auth@v2](https://github.com/google-github-actions/auth/releases/tag/v2.0.0)
