### PR TITLE
fix(dependabot): update /api + /updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,16 @@ updates:
     schedule:
       interval: daily
 
+  - package-ecosystem: npm
+    directory: "/api"
+    schedule:
+      interval: daily
+
+  - package-ecosystem: npm
+    directory: "/updates"
+    schedule:
+      interval: daily
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
We enabled Dependabot only for the root directory, but we also have `package-lock.json`s in `/api` and `/updates`, and these currently don't receive Dependabot PRs.