### PR TITLE
fix(api): keep hash of mdn_url

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -136,7 +136,7 @@ function getPathFromAbsoluteURL(absoluteUrl?: string) {
     return absoluteUrl;
   }
 
-  const slug = url.pathname;
+  const slug = url.pathname + url.hash;
   if (slug.startsWith("/docs/")) {
     return `/en-US${slug}`;
   }


### PR DESCRIPTION
Noticed in https://github.com/mdn/browser-compat-data/pull/25499.

Testing by deploying to stage: https://github.com/mdn/bcd-utils/actions/runs/12674342859