### PR TITLE
chore(deploy-api): print BCD version

### DIFF
--- a/.github/workflows/deploy-prod-api.yml
+++ b/.github/workflows/deploy-prod-api.yml
@@ -39,7 +39,10 @@ jobs:
 
       - run: npm ci
 
-      - run: npm update @mdn/browser-compat-data
+      - name: Update BCD package
+        run: |-
+          npm update @mdn/browser-compat-data
+          npm list @mdn/browser-compat-data
 
       - run: npm run generate
 

--- a/.github/workflows/deploy-stage-api.yml
+++ b/.github/workflows/deploy-stage-api.yml
@@ -39,7 +39,10 @@ jobs:
 
       - run: npm ci
 
-      - run: npm update @mdn/browser-compat-data
+      - name: Update BCD package
+        run: |-
+          npm update @mdn/browser-compat-data
+          npm list @mdn/browser-compat-data
 
       - run: npm run generate
 


### PR DESCRIPTION
It looks like the deployment uses the previous BCD version, possibly due to a race condition, i.e. the "just released" BCD version is not yet served from npm.

So let's print the BCD version during the deployment, to confirm this hypothesis.