### PR TITLE
chore(deps-peer): bump @mdn/browser-compat-data from v5 to v6 in `api/`

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -18,7 +18,8 @@ export interface SimpleSupportStatementExtended extends SimpleSupportStatement {
   release_date?: string;
 }
 
-export interface CompatStatementExtended extends CompatStatement {
+export interface CompatStatementExtended
+  extends Omit<CompatStatement, "support"> {
   support: Partial<Record<BrowserName, SimpleSupportStatementExtended[]>>;
 }
 

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,7 +1,6 @@
 import bcd, {
   BrowserName,
   Browsers,
-  BrowserStatement,
   CompatStatement,
   Identifier,
   SimpleSupportStatement,
@@ -17,7 +16,6 @@ export interface Data {
 
 export interface SimpleSupportStatementExtended extends SimpleSupportStatement {
   release_date?: string;
-  version_last?: VersionValue;
 }
 
 export interface CompatStatementExtended extends CompatStatement {
@@ -114,14 +112,10 @@ function extendSimpleSupportStatement(
   browserName: BrowserName,
 ): SimpleSupportStatementExtended {
   const added = normalizeVersion(statement.version_added);
-  const removed = normalizeVersion(statement.version_removed);
   return {
     ...statement,
     release_date: added
       ? browsers[browserName].releases[added]?.release_date
-      : undefined,
-    version_last: removed
-      ? _getPreviousVersion(removed, browsers[browserName])
       : undefined,
   };
 }
@@ -149,50 +143,4 @@ function normalizeVersion(version?: VersionValue): string | undefined {
       ? version.slice(1)
       : version
     : undefined;
-}
-
-// the functions below are copied from yari/build/document-extractor.ts unmodified:
-
-function _getPreviousVersion(
-  version: VersionValue,
-  browser: BrowserStatement,
-): VersionValue {
-  if (browser && typeof version === "string") {
-    const browserVersions = Object.keys(browser["releases"]).sort(
-      _compareVersions,
-    );
-    const currentVersionIndex = browserVersions.indexOf(version);
-    if (currentVersionIndex > 0) {
-      return browserVersions[currentVersionIndex - 1];
-    }
-  }
-
-  return version;
-}
-
-function _compareVersions(a: string, b: string) {
-  const x = _splitVersion(a);
-  const y = _splitVersion(b);
-
-  return _compareNumberArray(x, y);
-}
-
-function _splitVersion(version: string): number[] {
-  if (version.startsWith("≤")) {
-    version = version.slice(1);
-  }
-
-  return version.split(".").map(Number);
-}
-
-function _compareNumberArray(a: number[], b: number[]): number {
-  while (a.length || b.length) {
-    const x = a.shift() || 0;
-    const y = b.shift() || 0;
-    if (x !== y) {
-      return x - y;
-    }
-  }
-
-  return 0;
 }

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -16,7 +16,7 @@
         "typescript": "^5.4.5"
       },
       "peerDependencies": {
-        "@mdn/browser-compat-data": "^5.2.21"
+        "@mdn/browser-compat-data": "^6.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -57,9 +57,10 @@
       }
     },
     "node_modules/@mdn/browser-compat-data": {
-      "version": "5.2.39",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.39.tgz",
-      "integrity": "sha512-m8EJuQlHl6GeBkryBfJCl9gOOw/5dCqQVzRWj6hBbDG3NTaJyypa5784lae/uklYildVwiqbP0iGl3LUEhECPg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-6.0.0.tgz",
+      "integrity": "sha512-tmMexnVryVYx7Vzdg0x2Zs4xdxJoXtijQ55hUtdKLCO6nFctEYJPI6a+Ar2polVWhF+FPtCCNk+LVzNdA6LmBA==",
+      "license": "CC0-1.0",
       "peer": true
     },
     "node_modules/@tsconfig/node10": {
@@ -276,9 +277,9 @@
       }
     },
     "@mdn/browser-compat-data": {
-      "version": "5.2.39",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.39.tgz",
-      "integrity": "sha512-m8EJuQlHl6GeBkryBfJCl9gOOw/5dCqQVzRWj6hBbDG3NTaJyypa5784lae/uklYildVwiqbP0iGl3LUEhECPg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-6.0.0.tgz",
+      "integrity": "sha512-tmMexnVryVYx7Vzdg0x2Zs4xdxJoXtijQ55hUtdKLCO6nFctEYJPI6a+Ar2polVWhF+FPtCCNk+LVzNdA6LmBA==",
       "peer": true
     },
     "@tsconfig/node10": {

--- a/api/package.json
+++ b/api/package.json
@@ -27,6 +27,6 @@
     "typescript": "^5.4.5"
   },
   "peerDependencies": {
-    "@mdn/browser-compat-data": "^5.2.21"
+    "@mdn/browser-compat-data": "^6.0.0"
   }
 }


### PR DESCRIPTION
Changes:

1. Removes the obsolete `version_last` generation (it's already included in BCD since v5.5.0).
2. Improves the `CompatStatementExtended` type (to avoid issues with new BCD v6 types).
3. Bumps `@mdn/browser-compat-data` in the `peerDepencencies`. 