### PR TITLE
fix(workflows): disable cache in privileged workflows

### DIFF
--- a/.github/workflows/deploy-prod-updates.yml
+++ b/.github/workflows/deploy-prod-updates.yml
@@ -37,7 +37,6 @@ jobs:
         with:
           node-version-file: .nvmrc
           registry-url: "https://registry.npmjs.org/"
-          cache: npm
 
       - run: npm ci
 

--- a/.github/workflows/publish-package-api.yml
+++ b/.github/workflows/publish-package-api.yml
@@ -25,7 +25,6 @@ jobs:
         with:
           node-version-file: .nvmrc
           registry-url: "https://registry.npmjs.org/"
-          cache: npm
       - run: npm ci
       - run: npm update @mdn/browser-compat-data
       - run: npm test


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Disables the cache (used by `actions/setup-node`) in privileged workflows.

#### Test results and supporting details

This limits the impact of less-privileged workflows that may be vulnerable to code injection.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
