### PR TITLE
chore(deps-peer): bump @mdn/browser-compat-data from v6 to v7 in api/

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -16,7 +16,7 @@
         "typescript": "^5.4.5"
       },
       "peerDependencies": {
-        "@mdn/browser-compat-data": "^6.0.0"
+        "@mdn/browser-compat-data": "^7.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -57,9 +57,9 @@
       }
     },
     "node_modules/@mdn/browser-compat-data": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-6.0.0.tgz",
-      "integrity": "sha512-tmMexnVryVYx7Vzdg0x2Zs4xdxJoXtijQ55hUtdKLCO6nFctEYJPI6a+Ar2polVWhF+FPtCCNk+LVzNdA6LmBA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-7.0.0.tgz",
+      "integrity": "sha512-qyM4cMWS0ks9vwckN9gZ+opeNvnGTQKp83dANUlE06LlaINQEzfauG3QDQcyUPLsmMoV+br9GGAoSy4038mvRA==",
       "license": "CC0-1.0",
       "peer": true
     },
@@ -275,9 +275,9 @@
       }
     },
     "@mdn/browser-compat-data": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-6.0.0.tgz",
-      "integrity": "sha512-tmMexnVryVYx7Vzdg0x2Zs4xdxJoXtijQ55hUtdKLCO6nFctEYJPI6a+Ar2polVWhF+FPtCCNk+LVzNdA6LmBA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-7.0.0.tgz",
+      "integrity": "sha512-qyM4cMWS0ks9vwckN9gZ+opeNvnGTQKp83dANUlE06LlaINQEzfauG3QDQcyUPLsmMoV+br9GGAoSy4038mvRA==",
       "peer": true
     },
     "@tsconfig/node10": {

--- a/api/package.json
+++ b/api/package.json
@@ -27,6 +27,6 @@
     "typescript": "^5.4.5"
   },
   "peerDependencies": {
-    "@mdn/browser-compat-data": "^6.0.0"
+    "@mdn/browser-compat-data": "^7.0.0"
   }
 }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Bumps @mdn/browser-compat-data to v7.0.0.

### Motivation

Ensures updates continue to work.

### Additional details

In fact, the API deployment triggered by the v7.0.0 release only deployed the latest v6 release, see: https://github.com/mdn/bcd-utils/actions/runs/17162267622/job/48694186664#step:5:14

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

