### PR TITLE
ci(workflows): disable automatic setup-node caching

### DIFF
--- a/.github/workflows/deploy-prod-api.yml
+++ b/.github/workflows/deploy-prod-api.yml
@@ -37,6 +37,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
+          package-manager-cache: false
           registry-url: "https://registry.npmjs.org/"
 
       - run: npm ci

--- a/.github/workflows/deploy-prod-updates.yml
+++ b/.github/workflows/deploy-prod-updates.yml
@@ -36,6 +36,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
+          package-manager-cache: false
           registry-url: "https://registry.npmjs.org/"
 
       - run: npm ci

--- a/.github/workflows/deploy-stage-api.yml
+++ b/.github/workflows/deploy-stage-api.yml
@@ -37,6 +37,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
+          package-manager-cache: false
           registry-url: "https://registry.npmjs.org/"
 
       - run: npm ci

--- a/.github/workflows/deploy-stage-updates.yml
+++ b/.github/workflows/deploy-stage-updates.yml
@@ -36,6 +36,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
+          package-manager-cache: false
           registry-url: "https://registry.npmjs.org/"
 
       - run: npm ci

--- a/.github/workflows/publish-package-api.yml
+++ b/.github/workflows/publish-package-api.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
+          package-manager-cache: false
           registry-url: "https://registry.npmjs.org/"
       - run: npm ci
       - run: npm update @mdn/browser-compat-data


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Disables automatic caching introduced in [`actions/setup-node` v5](https://github.com/mdn/bcd-utils/pull/192).

### Motivation

The new default behavior is not safe in privileged workflows.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

See also:

- https://github.com/actions/setup-node/issues/1358

