### PR TITLE
chore(CODEOWNERS): make `@mdn/engineering` the default owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,3 +15,6 @@
 # If another reviewer is specified, update the PAT token or auto-merge will cease to be automatic.
 package.json @mdn-bot
 package-lock.json @mdn-bot
+
+/.github/workflows/ @mdn/engineering
+/.github/CODEOWNERS @mdn/core-dev @mdn/engineering

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,9 +6,7 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 # ----------------------------------------------------------------------------
 
-*    @mdn/engineering
+* @mdn/engineering
 
-# These are @mdn-bot because the auto-merge GHA workflow uses the PAT of this account.
-# If another reviewer is specified, update the PAT token or auto-merge will cease to be automatic.
-package.json @mdn-bot
-package-lock.json @mdn-bot
+package.json @mdn/engineering @mdn-bot
+package-lock.json @mdn/engineering @mdn-bot

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,9 +8,6 @@
 
 *    @mdn/engineering
 
-/.github/workflows/ @mdn/engineering
-/.github/CODEOWNERS @mdn/core-dev @mdn/engineering
-
 # These are @mdn-bot because the auto-merge GHA workflow uses the PAT of this account.
 # If another reviewer is specified, update the PAT token or auto-merge will cease to be automatic.
 package.json @mdn-bot

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,9 +6,6 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 # ----------------------------------------------------------------------------
 
-# ----------------------------------------------------------------------------
-# DEFAULT OWNERS
-# ----------------------------------------------------------------------------
 *    @mdn/engineering
 
 /.github/workflows/ @mdn/engineering

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,10 +11,10 @@
 # ----------------------------------------------------------------------------
 *    @mdn/core-dev
 
+/.github/workflows/ @mdn/engineering
+/.github/CODEOWNERS @mdn/core-dev @mdn/engineering
+
 # These are @mdn-bot because the auto-merge GHA workflow uses the PAT of this account.
 # If another reviewer is specified, update the PAT token or auto-merge will cease to be automatic.
 package.json @mdn-bot
 package-lock.json @mdn-bot
-
-/.github/workflows/ @mdn/engineering
-/.github/CODEOWNERS @mdn/core-dev @mdn/engineering

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@
 # ----------------------------------------------------------------------------
 # DEFAULT OWNERS
 # ----------------------------------------------------------------------------
-*    @mdn/core-dev
+*    @mdn/engineering
 
 /.github/workflows/ @mdn/engineering
 /.github/CODEOWNERS @mdn/core-dev @mdn/engineering


### PR DESCRIPTION
### Description

Updates the CODEOWNERS file to make `@mdn/engineering` the default owner, and additional owner for `package.json` and `package-lock.json`.

### Motivation

Ensures the engineering team has oversight of changes, and CODEOWNERS file modifications across repositories.

### Additional details

See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/888.