### PR TITLE
chore(api): bump version number

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mdn/bcd-utils-api",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mdn/bcd-utils-api",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "license": "MPL-2.0",
       "devDependencies": {
         "@types/node": "^24.10.3",

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdn/bcd-utils-api",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Converts bcd data into json files usable by yari's bcd table",
   "homepage": "https://github.com/mdn/bcd-utils#readme",
   "bugs": {


### PR DESCRIPTION
Necessary so we can do an npm release, to fix the version incompatibility on https://github.com/mdn/dex/pull/371