### PR TITLE
chore: scope package names under `@mdn/bcd-utils`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,10 @@
 {
-  "name": "bcd-utils",
+  "name": "@mdn/bcd-utils",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
+      "name": "@mdn/bcd-utils",
       "devDependencies": {
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^10.1.8",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "@mdn/bcd-utils",
   "scripts": {
     "lint": "eslint . && prettier --check ."
   },

--- a/updates/package-lock.json
+++ b/updates/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "bcd-updates",
+  "name": "@mdn/bcd-utils-updates",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "bcd-updates",
+      "name": "@mdn/bcd-utils-updates",
       "version": "1.0.0",
       "license": "MPL-2.0",
       "dependencies": {

--- a/updates/package.json
+++ b/updates/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bcd-updates",
+  "name": "@mdn/bcd-utils-updates",
   "version": "1.0.0",
   "description": "",
   "license": "MPL-2.0",


### PR DESCRIPTION
### Description

Scope all workspace package names under `@mdn/bcd-utils`:

- Add an explicit `name` (`@mdn/bcd-utils`) to the root `package.json`.
- Rename `bcd-updates` to `@mdn/bcd-utils-updates`.

### Motivation

Ensure the root package has a stable name instead of defaulting to the checkout directory name (which differs in worktrees), and make package names consistent with `@mdn/bcd-utils-api`.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->